### PR TITLE
Added sync command, delay to sync command.

### DIFF
--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -1047,7 +1047,7 @@ int netmd_write_track(netmd_dev_handle* devh, char* szFile)
 
             fprintf (stderr, "bytes left in chunk: %lu\n", (unsigned long)__bytes_left);
             p[6] = (__bytes_left >> 8) & 0xff;      /* Inserts the higher 8 bytes of the length */
-            p[7] = __bytes_left & 0xff;     /* Inserts the l./libnetmd/libnetmd.cower 8 bytes of the length */
+            p[7] = __bytes_left & 0xff;     /* Inserts the lower 8 bytes of the length */
             __chunk_size -= 0x10;          /* Update chunk size (for inserted header */
 
             p += 0x10;                     /* p should now point at the beginning of the next data segment */

--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -1047,7 +1047,7 @@ int netmd_write_track(netmd_dev_handle* devh, char* szFile)
 
             fprintf (stderr, "bytes left in chunk: %lu\n", (unsigned long)__bytes_left);
             p[6] = (__bytes_left >> 8) & 0xff;      /* Inserts the higher 8 bytes of the length */
-            p[7] = __bytes_left & 0xff;     /* Inserts the lower 8 bytes of the length */
+            p[7] = __bytes_left & 0xff;     /* Inserts the l./libnetmd/libnetmd.cower 8 bytes of the length */
             __chunk_size -= 0x10;          /* Update chunk size (for inserted header */
 
             p += 0x10;                     /* p should now point at the beginning of the next data segment */
@@ -1150,10 +1150,12 @@ int netmd_cache_toc(netmd_dev_handle* dev)
 
 int netmd_sync_toc(netmd_dev_handle* dev)
 {
+    usleep(100000);
     int ret = 0;
     unsigned char request[] = {0x00, 0x18, 0x08, 0x10, 0x18, 0x02, 0x00, 0x00};
     unsigned char reply[255];
 
     ret = netmd_exch_message(dev, request, sizeof(request), reply);
+    usleep(100000);
     return ret;
 }

--- a/netmdcli/netmdcli.c
+++ b/netmdcli/netmdcli.c
@@ -422,6 +422,10 @@ int main(int argc, char* argv[])
         {
             netmd_track_previous(devh);
         }
+        else if(strcmp("sync", argv[1]) == 0)
+        {
+            netmd_sync_toc(devh);
+        }
         else if(strcmp("restart", argv[1]) == 0)
         {
             netmd_track_restart(devh);
@@ -1014,6 +1018,7 @@ void print_syntax()
     puts("restart - restarts current track");
     puts("pause - pause the unit");
     puts("stop - stop the unit");
+    puts("sync - sync the unit (may be useful for ensuring TOC edits are committed to disk)");
     puts("delete #1 [#2] - delete track (or tracks in range #1-#2 if #2 given)");
     puts("m3uimport <file> - import song and disc title from a playlist");
     puts("send <file> [<string>] - send WAV format audio file to the device and set title to <string> (optional)");


### PR DESCRIPTION
This PR contain a seperate sync command, which was updated with usleep. This allows me to affect changes to MDs with my MZ-N505. `netmdcli` is now by no means error free, but at least it is workable.

Potentially the usleep cound be moved from `netmd_sync_toc` into just the sync command, if people are worried the delays are untenable for users not requiring it.