### PR TITLE
Add netmd_acquire_dev and netmd_release_dev functions to support Sharp IM-DR420 (and possibly others)

### DIFF
--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -1157,3 +1157,25 @@ int netmd_sync_toc(netmd_dev_handle* dev)
     ret = netmd_exch_message(dev, request, sizeof(request), reply);
     return ret;
 }
+
+int netmd_acquire_dev(netmd_dev_handle* dev)
+{
+    int ret = 0;
+    unsigned char request[] = {0x00, 0xff, 0x01, 0x0c, 0xff, 0xff, 0xff, 0xff,
+                               0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    unsigned char reply[255];
+
+    ret = netmd_exch_message(dev, request, sizeof(request), reply);
+    return ret;
+}
+
+int netmd_release_dev(netmd_dev_handle* dev)
+{
+    int ret = 0;
+    unsigned char request[] = {0x00, 0xff, 0x01, 0x00, 0xff, 0xff, 0xff, 0xff,
+                               0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    unsigned char reply[255];
+
+    ret = netmd_exch_message(dev, request, sizeof(request), reply);
+    return ret;
+}

--- a/libnetmd/libnetmd.h
+++ b/libnetmd/libnetmd.h
@@ -245,3 +245,5 @@ int netmd_wait_for_sync(netmd_dev_handle* dev);
 
 int netmd_cache_toc(netmd_dev_handle* dev);
 int netmd_sync_toc(netmd_dev_handle* dev);
+int netmd_acquire_dev(netmd_dev_handle* dev);
+int netmd_release_dev(netmd_dev_handle* dev);

--- a/netmdcli/netmdcli.c
+++ b/netmdcli/netmdcli.c
@@ -858,6 +858,9 @@ netmd_error send_track(netmd_dev_handle *devh, const char *filename, const char 
         }
     }
 
+    error = netmd_acquire_dev(devh);
+    netmd_log(NETMD_LOG_VERBOSE, "netmd_acquire_dev: %s\n", netmd_strerror(error));
+
     error = netmd_secure_leave_session(devh);
     netmd_log(NETMD_LOG_VERBOSE, "netmd_secure_leave_session : %s\n", netmd_strerror(error));
 
@@ -988,6 +991,9 @@ netmd_error send_track(netmd_dev_handle *devh, const char *filename, const char 
     /* leave session */
     cleanup_error = netmd_secure_leave_session(devh);
     netmd_log(NETMD_LOG_VERBOSE, "netmd_secure_leave_session : %s\n", netmd_strerror(cleanup_error));
+
+	cleanup_error = netmd_release_dev(devh);
+	netmd_log(NETMD_LOG_VERBOSE, "netmd_release_dev : %s\n", netmd_strerror(cleanup_error));
 
     return error; /* return error code from the "business logic" */
 }


### PR DESCRIPTION
At least the Sharp IM-DR420 NetMD recorder only allows track downloads if exclusive access to the device has been requested. Otherwise, it rejects all secure commands with `0x0a`.

This PR adds two new functions to `libnetmd.c` and calls them when sending a track. While it should not hurt other devices, I haven't tested this.