### PR TITLE
Fix OS X building on Apple Silicon

### DIFF
--- a/build/common.pri
+++ b/build/common.pri
@@ -6,5 +6,7 @@ QMAKE_LFLAGS += $$(LDFLAGS)
 macx {
   # Dependencies from Homebrew are put here
   INCLUDEPATH += /usr/local/include
+  INCLUDEPATH += /opt/homebrew/include
   LIBS += -L/usr/local/lib
+  LIBS += -L/opt/homebrew/lib
 }


### PR DESCRIPTION
Hi! Thanks so much for all your work on this, it's been so amazing getting to use MiniDiscs again!

I tried to build a new installation on an M1 MacBook Air tonight and ran into an issue with it not finding the Homebrew build dependencies in their new location for Apple Silicon -- this PR adds the new path (/opt/homebrew) to the common.pri file so it knows where to find them. (The old path is still there so it still builds with Intel Homebrew installations, and I tested it successfully on an Intel MacBook Air as well.)